### PR TITLE
Use context manager for test file writing

### DIFF
--- a/tests/test_rtf.py
+++ b/tests/test_rtf.py
@@ -10,7 +10,8 @@ from rtf import RTF, main
 
 
 def write_rtf(path: Path, text: str) -> None:
-    path.write_text("{\\rtf1\n\n" + text + "}", encoding="latin-1")
+    with path.open("w", encoding="latin-1") as file:
+        file.write("{\\rtf1\n\n" + text + "}")
 
 
 def test_to_plain_text(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Ensure temporary RTF helper uses a context manager when writing files

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893d9293c008326b36ad71da952f10d