### PR TITLE
refactor: adopt src layout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,4 +17,8 @@ dev = [
 
 [tool.pyright]
 typeCheckingMode = "strict"
+extraPaths = ["src"]
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
 

--- a/src/rtf/__init__.py
+++ b/src/rtf/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Simple utilities for converting RTF documents to plain text."""
 
 from __future__ import annotations
@@ -75,13 +74,13 @@ class RTF:
                                     for c in fallback
                                 ):  # pragma: no cover
                                     raise ValueError(
-                                        "Invalid unicode fallback"
+                                        "Invalid unicode fallback",
                                     )  # pragma: no cover
                             elif char == "\\":
                                 next_char = file.read(1)
                                 if next_char != "'":  # pragma: no cover
                                     raise ValueError(
-                                        "Invalid unicode fallback"
+                                        "Invalid unicode fallback",
                                     )  # pragma: no cover
                                 fallback = file.read(2)
                                 if len(fallback) < 2 or any(
@@ -89,7 +88,7 @@ class RTF:
                                     for c in fallback
                                 ):  # pragma: no cover
                                     raise ValueError(
-                                        "Invalid unicode fallback"
+                                        "Invalid unicode fallback",
                                     )  # pragma: no cover
                             elif char not in {" ", "\n"}:  # pragma: no cover
                                 pass
@@ -177,4 +176,4 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    main()  # pragma: no cover

--- a/src/rtf/__main__.py
+++ b/src/rtf/__main__.py
@@ -1,0 +1,4 @@
+from . import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- adopt a `src/` layout and expose the package as `rtf`
- support running the module with `python -m rtf`
- configure tooling to look inside the new `src` tree

## Testing
- `uvx pre-commit run --files pyproject.toml src/rtf/__init__.py src/rtf/__main__.py tests/test_rtf.py`

------
https://chatgpt.com/codex/tasks/task_e_6893ff2ce3408326b746f8305eb7dcd9